### PR TITLE
use `config.basePath` for `ignorePatterns`

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -634,40 +634,13 @@ class ConfigLoader {
 
 		// append command line ignore patterns
 		if (ignorePatterns && ignorePatterns.length > 0) {
-			let relativeIgnorePatterns;
-
-			/*
-			 * If the config file basePath is different than the cwd, then
-			 * the ignore patterns won't work correctly. Here, we adjust the
-			 * ignore pattern to include the correct relative path. Patterns
-			 * passed as `ignorePatterns` are relative to the cwd, whereas
-			 * the config file basePath can be an ancestor of the cwd.
-			 */
-			if (basePath === cwd) {
-				relativeIgnorePatterns = ignorePatterns;
-			} else {
-				// relative path must only have Unix-style separators
-				const relativeIgnorePath = path
-					.relative(basePath, cwd)
-					.replace(/\\/gu, "/");
-
-				relativeIgnorePatterns = ignorePatterns.map(pattern => {
-					const negated = pattern.startsWith("!");
-					const basePattern = negated ? pattern.slice(1) : pattern;
-
-					return (
-						(negated ? "!" : "") +
-						path.posix.join(relativeIgnorePath, basePattern)
-					);
-				});
-			}
-
 			/*
 			 * Ignore patterns are added to the end of the config array
 			 * so they can override default ignores.
 			 */
 			configs.push({
-				ignores: relativeIgnorePatterns,
+				basePath: cwd,
+				ignores: ignorePatterns,
 			});
 		}
 

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -21,7 +21,7 @@ const { Config } = require("./config");
 /**
  * Fields that are considered metadata and not part of the config object.
  */
-const META_FIELDS = new Set(["name"]);
+const META_FIELDS = new Set(["name", "basePath"]);
 
 /**
  * Wraps a config error with details about where the error occurred.

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1766,6 +1766,13 @@ export namespace Linter {
 		name?: string;
 
 		/**
+		 * Path to the directory where the configuration object should apply.
+		 * `files` and `ignores` patterns in the configuration object are
+		 * interpreted as relative to this path.
+		 */
+		basePath?: string;
+
+		/**
 		 * An array of glob patterns indicating the files that the configuration
 		 * object should apply to. If not specified, the configuration object applies
 		 * to all files


### PR DESCRIPTION
Proof of concept for the RFC Support `basePath` property in config objects.